### PR TITLE
add: platform option

### DIFF
--- a/week25-1/Dockerfile
+++ b/week25-1/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM mysql:8.0.29-debian
+FROM --platform=linux/x86_64 mysql:8.0.29-debian
 RUN apt-get update && apt-get install -y locales \
     && sed -i -e 's/# \(ja_JP.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen \


### PR DESCRIPTION
### 目的

- M1で動作しない週があり、platformの指定ができた

### やったこと

- Dockerfileのみの場合は FROM句に `FROM --platform=linux/x86_64 ` を追加