### PR TITLE
fix: week20-1のreadmeのアクセスする先のリンクについて補足を追加

### DIFF
--- a/src/week20-1/README.md
+++ b/src/week20-1/README.md
@@ -4,6 +4,8 @@
 
 docker compose up したのちに localhost:8080/week20-1/index.php にアクセスするとエラーが表示されます
 
+※ localhost:3000 でアクセスできるように変更している場合、①localhost:8080 にアクセスできるようにする、あるいは ②localhost:3000 を用いてアクセスするようにしてください。
+
 ```
 SQLSTATE[HY000] [2002] No such file or directory
 ```


### PR DESCRIPTION
## なぜこの変更が必要か
week17-2のドリル課題で localhost:3000 に変更したままで、week20-1で久しぶりにブラウザでページにアクセスする際に localhost:8080 にアクセスするように記載があった
↓
久しぶりにブラウザにアクセスするのでここの壁にぶち当たる人が多かったため
＋
ドリル課題自体は解けているのにlocalhost:8080にアクセスしてもエラーが出たままで、「自力で解けなかった」、というモチベが下がる現象を避けるため