### PR TITLE
Update MySQL and PHP versions in Dockerfiles

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,17 +1,17 @@
-# apt-getを利用するためにDebianベースのMySQL 8.0.35を使用
-FROM mysql:8.0.35-debian
+# debianをベースにする場合は、OS/ARCHが1択になってしまうので変更する場合は注意
+# MySQL 8.0 を使用
+FROM mysql:8
 
-# 必要なパッケージのインストール
-RUN apt-get update && \
-    apt-get install -y locales
+# Oracle Linux のためのパッケージマネージャーのインストール
+USER root
+RUN microdnf install -y glibc-locale-source glibc-langpack-en
 
 # 日本語ロケールの生成と設定
-RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
+RUN localedef -i ja_JP -f UTF-8 ja_JP.UTF-8
 
 # 環境変数の設定
 ENV LANG ja_JP.UTF-8
 ENV LC_ALL ja_JP.UTF-8
 
 # キャッシュと不要なファイルの削除
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN microdnf clean all

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,11 +1,17 @@
-# apt-get出来る様にdebian版を使う。
-FROM mysql:8.0.33-debian
-# コンテナ内で日本語が打てるようにlocalを変更といらないファイル削除
-RUN apt-get update \
-  && apt-get install -y locales \
-  && sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen \
-  && locale-gen \
-  && update-locale LANG=ja_JP.UTF-8 \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+# apt-getを利用するためにDebianベースのMySQL 8.0.35を使用
+FROM mysql:8.0.35-debian
+
+# 必要なパッケージのインストール
+RUN apt-get update && \
+    apt-get install -y locales
+
+# 日本語ロケールの生成と設定
+RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
+
+# 環境変数の設定
+ENV LANG ja_JP.UTF-8
 ENV LC_ALL ja_JP.UTF-8
+
+# キャッシュと不要なファイルの削除
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,5 +1,3 @@
-# debianをベースにする場合は、OS/ARCHが1択になってしまうので変更する場合は注意
-# MySQL 8.0 を使用
 FROM mysql:8
 
 # Oracle Linux のためのパッケージマネージャーのインストール
@@ -12,6 +10,10 @@ RUN localedef -i ja_JP -f UTF-8 ja_JP.UTF-8
 # 環境変数の設定
 ENV LANG ja_JP.UTF-8
 ENV LC_ALL ja_JP.UTF-8
+# タイムゾーン(東京)
+ENV TZ Asia/Tokyo
+# MySQLのconfigファイル(my.cnf)をコピー
+COPY ./docker/mysql/my.cnf /etc/my.cnf
 
 # キャッシュと不要なファイルの削除
 RUN microdnf clean all

--- a/db/conf.d/my.cnf
+++ b/db/conf.d/my.cnf
@@ -1,8 +1,11 @@
-[mysqld]
+user=mysql
 character_set_server = utf8mb4
-collation_server = utf8mb4_general_ci
+collation_server = utf8mb4_0900_ai_ci
+mysql_native_password=on
 
-[mysql]
+# timezone
+default-time-zone = SYSTEM
+
 default-character-set = utf8mb4
 
 [client]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     build:
       context: .
       dockerfile: "./db/Dockerfile"
-    platform: linux/x86_64
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_DATABASE=ph2drill

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     build:
       context: .
       dockerfile: "./db/Dockerfile"
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_DATABASE=ph2drill
       - MYSQL_ROOT_PASSWORD=password

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm
+FROM php:8-fpm
 
 COPY php.ini /usr/local/etc/php/
 


### PR DESCRIPTION
## 起きている問題
mysql用のDockerfileでapt-getしている箇所でエラーが発生していた。
なので日本語化対応を別の対応に変更して、正しく動作するのかを確認したい

## エラーの内容
```
PS C:\Users\XXX\workspace\drill-ph2> docker compose build
[+] Building 4.4s (5/5) FINISHED                                                                                                                                  docker:default
=> [db internal] load build definition from Dockerfile                                                                                                                     0.0s
=> => transferring dockerfile: 462B                                                                                                                                        0.0s
=> [db internal] load .dockerignore                                                                                                                                        0.0s
=> => transferring context: 2B                                                                                                                                             0.0s
=> [db internal] load metadata for [docker.io/library/mysql:8.0.33-debian](http://docker.io/library/mysql:8.0.33-debian)                                                                                                   1.3s
=> CACHED [db 1/2] FROM [docker.io/library/mysql:8.0.33-debian@sha256:7cade3f2720efda2be0e6184d8e050d1c3b9e84297e18d9a4566173afe41a031](http://docker.io/library/mysql:8.0.33-debian@sha256:7cade3f2720efda2be0e6184d8e050d1c3b9e84297e18d9a4566173afe41a031)                                      0.0s
=> ERROR [db 2/2] RUN apt-get update   && apt-get install -y locales   && sed -i -E ‘s/# (ja_JP.UTF-8)/\1/’ /etc/locale.gen   && locale-gen   && update-locale LANG=ja_JP  3.0s
------
> [db 2/2] RUN apt-get update   && apt-get install -y locales   && sed -i -E ‘s/# (ja_JP.UTF-8)/\1/’ /etc/locale.gen   && locale-gen   && update-locale LANG=ja_JP.UTF-8   && ap0.298 Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
0.323 Get:2 http://repo.mysql.com/apt/debian bullseye InRelease [17.9 kB]
0.347 Get:3 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
0.370 Err:2 http://repo.mysql.com/apt/debian bullseye InRelease
0.370   The following signatures couldn’t be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
0.377 Get:4 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
0.468 Get:5 http://deb.debian.org/debian bullseye/main amd64 Packages [8062 kB]
1.839 Get:6 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [265 kB]
1.919 Get:7 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]
2.632 Reading package lists...
3.030 W: GPG error: http://repo.mysql.com/apt/debian bullseye InRelease: The following signatures couldn’t be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
3.030 E: The repository ‘http://repo.mysql.com/apt/debian bullseye InRelease’ is not signed.
------
failed to solve: process “/bin/sh -c apt-get update   && apt-get install -y locales   && sed -i -E ‘s/# (ja_JP.UTF-8)/\\1/’ /etc/locale.gen   && locale-gen   && update-locale LANG=ja_JP.UTF-8   && apt-get clean   && rm -rf /var/lib/apt/lists/*” did not complete successfully: exit code: 100
```


## 日本語が打てる証跡

![スクリーンショット 2024-01-14 14 22 55](https://github.com/posse-ap/drill-ph2/assets/33271639/55ec2f89-8fcf-4348-9fdc-6d300c9f2b0d)
